### PR TITLE
Adds default value to prevent crash from nil value

### DIFF
--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -141,14 +141,14 @@
 {
     [self.analytics track:@"Install Attributed" properties:@{
         @"provider" : @"Adjust",
-        @"trackerToken" : attribution.trackerToken ?: @"",
-        @"trackerName" : attribution.trackerName ?: @"",
+        @"trackerToken" : attribution.trackerToken ?: [NSNull null],
+        @"trackerName" : attribution.trackerName ?: [NSNull null],
         @"campaign" : @{
-            @"source" : attribution.network ?: @"",
-            @"name" : attribution.campaign ?: @"",
-            @"content" : attribution.clickLabel ?: @"",
-            @"adCreative" : attribution.creative ?: @"",
-            @"adGroup" : attribution.adgroup ?: @"",
+            @"source" : attribution.network ?: [NSNull null],
+            @"name" : attribution.campaign ?: [NSNull null],
+            @"content" : attribution.clickLabel ?: [NSNull null],
+            @"adCreative" : attribution.creative ?: [NSNull null],
+            @"adGroup" : attribution.adgroup ?: [NSNull null]
         }
     }];
 }

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -141,14 +141,14 @@
 {
     [self.analytics track:@"Install Attributed" properties:@{
         @"provider" : @"Adjust",
-        @"trackerToken" : attribution.trackerToken,
-        @"trackerName" : attribution.trackerName,
+        @"trackerToken" : attribution.trackerToken ?: @"",
+        @"trackerName" : attribution.trackerName ?: @"",
         @"campaign" : @{
-            @"source" : attribution.network,
-            @"name" : attribution.campaign,
-            @"content" : attribution.clickLabel,
-            @"adCreative" : attribution.creative,
-            @"adGroup" : attribution.adgroup,
+            @"source" : attribution.network ?: @"",
+            @"name" : attribution.campaign ?: @"",
+            @"content" : attribution.clickLabel ?: @"",
+            @"adCreative" : attribution.creative ?: @"",
+            @"adGroup" : attribution.adgroup ?: @"",
         }
     }];
 }


### PR DESCRIPTION
CC @ssevans  

Invoice2Go is seeing [a crash](https://segment.zendesk.com/attachments/token/UbwmV4kgKW7ODKWXhZ06n9Kfp/?name=com.invoice2go.plus_issue_25283_crash_2befce6232294333a0ba9d8d3cb353fe_775f124767ff11e7b9ef56847afe9799_0_v2.txt) in the Segment-Adjust SDK due to possible nil values based on the crash report.

This adds a default value of an empty String to guard against possible `nil` values.