### PR TITLE
Sets anonymousId on track via Adjust's addPartnerParam method

### DIFF
--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -1,4 +1,5 @@
 #import "SEGAdjustIntegration.h"
+#import <Analytics/SEGAnalyticsUtils.h>
 
 
 @implementation SEGAdjustIntegration
@@ -98,6 +99,12 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
+    NSString *segmentAnonymousId = [[SEGAnalytics sharedAnalytics] getAnonymousId];
+    if (segmentAnonymousId != nil && [segmentAnonymousId length] != 0) {
+        [Adjust addSessionPartnerParameter:@"anonymous_id" value:segmentAnonymousId];
+        SEGLog(@"[Adjust addSessionPartnerParameter:%@]", segmentAnonymousId);
+    }
+
     NSString *token = [self getMappedCustomEventToken:payload.event];
     if (token) {
         ADJEvent *event = [ADJEvent eventWithEventToken:token];


### PR DESCRIPTION
Attribution data being sent back from Adjust is silently failing (since Segment requires one unique identifier (whether a `userId`  or `anonymousId` on all calls), and the only way to send Adjust the Segment `userId` or `anonymousId` is through  the `setSessionPartnerParameter` method, which we only mapped on `identify`. This now sets the `anonymousId` on all `track` events, so Segment can receive the `Install Attributed` event with the `anonymousId` attached.

We decided not to map `userId` because 
1. analytics-ios does not have a getter function to retrieve the `userId`. We would have had to store to disc which take more time to implement, and this fix is urgent
2. Since the issue is around attribution events not having one of the required fields prior to `identify` being called, the `anonymousId` will be the only value present since `identify` has not been called and thus the `userId` has not been set

For Surfline, JIRA ticket [here](https://segment.atlassian.net/browse/PLATFORM-1209)