### PR TITLE
Add static libraries workaround for Swift projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ To install the Segment-Adjust integration, simply add this line to your [CocoaPo
 pod "Segment-Adjust"
 ```
 
+### Troubleshooting
+
+For users who are unable to bundle static libraries as dependencies (Swift project for example) you can choose `StaticLibWorkaround` subspec, but be sure to include `Adjust` to your Podfile:
+
+Example:
+
+```ruby
+  pod 'Adjust'
+  pod 'Segment-Adjust/StaticLibWorkaround'
+```
+
+Next step, add manually 4 files to your project (located under `<YOUR_APP>/Pods/Segment-Adjust/Pod/Classes`):
+
+ - `SEGAdjustIntegration.h`
+ - `SEGAdjustIntegration.m`
+ - `SEGAdjustIntegrationFactory.h`
+ - `SEGAdjustIntegrationFactory.m`
+
+Xcode will ask you to generate `<YOUR_APP_NAME>-Bridging-Header.h`
+Add to this file `#import "SEGAdjustIntegrationFactory.h"`
+
+For more details follow the instructions from Apple [here](https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html).
+
 ## Usage
 
 After adding the dependency, you must register the integration with our SDK.  To do this, import the Adjust integration in your `AppDelegate`:

--- a/Segment-Adjust.podspec
+++ b/Segment-Adjust.podspec
@@ -23,4 +23,12 @@ Pod::Spec.new do |s|
 
   s.dependency 'Analytics', '~> 3.0'
   s.dependency 'Adjust', '~> 4.10'
+
+  s.subspec 'StaticLibWorkaround' do |workaround|
+    # For users who are unable to bundle static libraries as dependencies
+    # you can choose this subspec, but be sure to include the following in your Podfile:
+    # pod 'Adjust','~> 4.10'
+    # Please manually add the following file preserved by Cocoapods to your xcodeproj file
+    workaround.preserve_paths = 'Pod/Classes/**/*'
+  end
 end


### PR DESCRIPTION
Add workaround for users who are unable to bundle static libraries as dependencies (Swift project for example)