### PR TITLE
Adds setting to delay start

### DIFF
--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -30,10 +30,9 @@
             [adjustConfig setDelegate:self];
         }
 
-        // The maximum delay start time of the adjust SDK is 10 seconds.
         if ([self setDelay]) {
             double delayTime = [settings[@"delayTime"] doubleValue];
-            [adjustConfig setDelayStart:MIN(delayTime, 10)];
+            [adjustConfig setDelayStart:delayTime];
         }
 
         [Adjust appDidLaunch:adjustConfig];

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -29,11 +29,10 @@
         if ([self trackAttributionData]) {
             [adjustConfig setDelegate:self];
         }
-
         double delayTime = [settings[@"delayTime"] doubleValue];
         // The maximum delay start time of the adjust SDK is 10 seconds.
-        if ([self setDelay] && (delayTime < 10.00)) {
-            [adjustConfig setDelayStart:delayTime];
+        if ([self setDelay]) {
+            [adjustConfig setDelayStart:MIN(delayTime, 10)];
         }
 
         [Adjust appDidLaunch:adjustConfig];

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -29,9 +29,10 @@
         if ([self trackAttributionData]) {
             [adjustConfig setDelegate:self];
         }
-        double delayTime = [settings[@"delayTime"] doubleValue];
+
         // The maximum delay start time of the adjust SDK is 10 seconds.
         if ([self setDelay]) {
+            double delayTime = [settings[@"delayTime"] doubleValue];
             [adjustConfig setDelayStart:MIN(delayTime, 10)];
         }
 

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -18,14 +18,22 @@
         if ([self setEnvironmentProduction]) {
             environment = ADJEnvironmentProduction;
         }
+
         ADJConfig *adjustConfig = [ADJConfig configWithAppToken:appToken
                                                     environment:environment];
 
         if ([self setEventBufferingEnabled]) {
             [adjustConfig setEventBufferingEnabled:YES];
         }
+
         if ([self trackAttributionData]) {
             [adjustConfig setDelegate:self];
+        }
+
+        double delayTime = [settings[@"delayTime"] doubleValue];
+        // The maximum delay start time of the adjust SDK is 10 seconds.
+        if ([self setDelay] && (delayTime < 10.00)) {
+            [adjustConfig setDelayStart:delayTime];
         }
 
         [Adjust appDidLaunch:adjustConfig];
@@ -183,5 +191,9 @@
     return [(NSNumber *)[self.settings objectForKey:@"trackAttributionData"] boolValue];
 }
 
+- (BOOL)setDelay
+{
+    return [(NSNumber *)[self.settings objectForKey:@"setDelay"] boolValue];
+}
 
 @end


### PR DESCRIPTION
The Adjust iOS SDK has a configuration to set a delay for their SDK https://github.com/adjust/ios_sdk#delay-start

The Adjust integration sometimes does not track the install attribution properly, and after contacting the Adjust support they suggested configuring a delay for their reporting to ensure all session parameters have been loaded properly (including the ones from Segment).

This fix will allow users to set the delay if `settings.setDelay` is enabled and the delay start time does not exceed 10 seconds. 
