### PR TITLE
App secret

### DIFF
--- a/Pod/Classes/SEGAdjustAppSecret.h
+++ b/Pod/Classes/SEGAdjustAppSecret.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+
+@interface SEGAdjustAppSecret : NSObject
+
+@property (nonatomic, readonly) NSUInteger ID;
+@property (nonatomic, readonly) NSUInteger info1;
+@property (nonatomic, readonly) NSUInteger info2;
+@property (nonatomic, readonly) NSUInteger info3;
+@property (nonatomic, readonly) NSUInteger info4;
+
+- (instancetype)initWithID:(NSUInteger)ID
+                     info1:(NSUInteger)info1
+                     info2:(NSUInteger)info2
+                     info3:(NSUInteger)info3
+                     info4:(NSUInteger)info4;
+
+@end

--- a/Pod/Classes/SEGAdjustAppSecret.m
+++ b/Pod/Classes/SEGAdjustAppSecret.m
@@ -1,0 +1,34 @@
+#import "SEGAdjustAppSecret.h"
+
+
+@interface SEGAdjustAppSecret ()
+
+@property (nonatomic, assign) NSUInteger ID;
+@property (nonatomic, assign) NSUInteger info1;
+@property (nonatomic, assign) NSUInteger info2;
+@property (nonatomic, assign) NSUInteger info3;
+@property (nonatomic, assign) NSUInteger info4;
+
+@end
+
+
+@implementation SEGAdjustAppSecret
+
+#pragma mark - Initialization
+
+- (instancetype)initWithID:(NSUInteger)ID
+                     info1:(NSUInteger)info1
+                     info2:(NSUInteger)info2
+                     info3:(NSUInteger)info3
+                     info4:(NSUInteger)info4 {
+    if (self = [super init]) {
+        self.ID = ID;
+        self.info1 = info1;
+        self.info2 = info2;
+        self.info3 = info3;
+        self.info4 = info4;
+    }
+    return self;
+}
+
+@end

--- a/Pod/Classes/SEGAdjustIntegration.h
+++ b/Pod/Classes/SEGAdjustIntegration.h
@@ -8,6 +8,6 @@
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) SEGAnalytics *analytics;
 
-- (instancetype)initWithSettings:(NSDictionary *)settings withAnalytics:(SEGAnalytics *)analytics;
+- (instancetype)initWithAppSecret:(nullable NSArray<NSNumber *> *)secret settings:(NSDictionary *)settings analytics:(SEGAnalytics *)analytics;
 
 @end

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -1,4 +1,5 @@
 #import "SEGAdjustIntegration.h"
+#import "SEGAdjustAppSecret.h"
 #import <Analytics/SEGAnalyticsUtils.h>
 
 
@@ -6,7 +7,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithAppSecret:(nullable NSArray<NSNumber *> *)secret settings:(NSDictionary *)settings analytics:(SEGAnalytics *)analytics
+- (instancetype)initWithAppSecret:(nullable SEGAdjustAppSecret *)secret settings:(NSDictionary *)settings analytics:(SEGAnalytics *)analytics
 {
     if (self = [super init]) {
         self.settings = settings;
@@ -23,15 +24,13 @@
                                                     environment:environment];
 
         if (secret != nil) {
-            NSAssert(secret.count == 5, @"App secret must contain a secret id followed by four info values");
-
             if ([adjustConfig respondsToSelector: @selector(setAppSecret:info1:info2:info3:info4:)]) {
 
-                [adjustConfig setAppSecret:secret[0].unsignedIntegerValue
-                                     info1:secret[1].unsignedIntegerValue
-                                     info2:secret[2].unsignedIntegerValue
-                                     info3:secret[3].unsignedIntegerValue
-                                     info4:secret[4].unsignedIntegerValue];
+                [adjustConfig setAppSecret:secret.ID
+                                     info1:secret.info1
+                                     info2:secret.info2
+                                     info3:secret.info3
+                                     info4:secret.info4];
             } else {
                 SEGLog(@"App secret not supported by current Adjust version");
             }

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -6,7 +6,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithSettings:(NSDictionary *)settings withAnalytics:(SEGAnalytics *)analytics
+- (instancetype)initWithAppSecret:(nullable NSArray<NSNumber *> *)secret settings:(NSDictionary *)settings analytics:(SEGAnalytics *)analytics
 {
     if (self = [super init]) {
         self.settings = settings;
@@ -21,6 +21,21 @@
 
         ADJConfig *adjustConfig = [ADJConfig configWithAppToken:appToken
                                                     environment:environment];
+
+        if (secret != nil) {
+            NSAssert(secret.count == 5, @"App secret must contain a secret id followed by four info values");
+
+            if ([adjustConfig respondsToSelector: @selector(setAppSecret:info1:info2:info3:info4:)]) {
+
+                [adjustConfig setAppSecret:secret[0].unsignedIntegerValue
+                                     info1:secret[1].unsignedIntegerValue
+                                     info2:secret[2].unsignedIntegerValue
+                                     info3:secret[3].unsignedIntegerValue
+                                     info4:secret[4].unsignedIntegerValue];
+            } else {
+                SEGLog(@"App secret not supported by current Adjust version");
+            }
+        }
 
         if ([self setEventBufferingEnabled]) {
             [adjustConfig setEventBufferingEnabled:YES];

--- a/Pod/Classes/SEGAdjustIntegrationFactory.h
+++ b/Pod/Classes/SEGAdjustIntegrationFactory.h
@@ -1,10 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
 
+@class SEGAdjustAppSecret;
+
 
 @interface SEGAdjustIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
-+ (instancetype)instanceWithAppSecret:(nullable NSArray<NSNumber *> *)secret;
++ (instancetype)instanceWithAppSecret:(nullable SEGAdjustAppSecret *)secret NS_SWIFT_NAME(instance(appSecret:));
 
 @end

--- a/Pod/Classes/SEGAdjustIntegrationFactory.h
+++ b/Pod/Classes/SEGAdjustIntegrationFactory.h
@@ -5,5 +5,6 @@
 @interface SEGAdjustIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
++ (instancetype)instanceWithAppSecret:(nullable NSArray<NSNumber *> *)secret;
 
 @end

--- a/Pod/Classes/SEGAdjustIntegrationFactory.m
+++ b/Pod/Classes/SEGAdjustIntegrationFactory.m
@@ -2,27 +2,34 @@
 #import "SEGAdjustIntegration.h"
 
 
-@implementation SEGAdjustIntegrationFactory
+@implementation SEGAdjustIntegrationFactory {
+    NSArray<NSNumber *> *appSecret;
+}
 
-+ (instancetype)instance
++ (instancetype)instance {
+    return [self instanceWithAppSecret: nil];
+}
+
++ (instancetype)instanceWithAppSecret: (nullable NSArray<NSNumber *> *)secret
 {
     static dispatch_once_t once;
     static SEGAdjustIntegrationFactory *sharedInstance;
     dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[self alloc] initWithAppSecret: secret];
     });
     return sharedInstance;
 }
 
-- (instancetype)init
+- (instancetype)initWithAppSecret: (NSArray<NSNumber *> *)secret
 {
     self = [super init];
+    appSecret = secret;
     return self;
 }
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGAdjustIntegration alloc] initWithSettings:settings withAnalytics:analytics];
+    return [[SEGAdjustIntegration alloc] initWithAppSecret: appSecret settings:settings analytics:analytics];
 }
 
 - (NSString *)key

--- a/Pod/Classes/SEGAdjustIntegrationFactory.m
+++ b/Pod/Classes/SEGAdjustIntegrationFactory.m
@@ -1,16 +1,17 @@
 #import "SEGAdjustIntegrationFactory.h"
 #import "SEGAdjustIntegration.h"
+#import "SEGAdjustAppSecret.h"
 
 
 @implementation SEGAdjustIntegrationFactory {
-    NSArray<NSNumber *> *appSecret;
+    SEGAdjustAppSecret *appSecret;
 }
 
 + (instancetype)instance {
     return [self instanceWithAppSecret: nil];
 }
 
-+ (instancetype)instanceWithAppSecret: (nullable NSArray<NSNumber *> *)secret
++ (instancetype)instanceWithAppSecret: (nullable SEGAdjustAppSecret *)secret
 {
     static dispatch_once_t once;
     static SEGAdjustIntegrationFactory *sharedInstance;
@@ -20,7 +21,7 @@
     return sharedInstance;
 }
 
-- (instancetype)initWithAppSecret: (NSArray<NSNumber *> *)secret
+- (instancetype)initWithAppSecret: (SEGAdjustAppSecret *)secret
 {
     self = [super init];
     appSecret = secret;


### PR DESCRIPTION
This PR adds support for the [app secret feature](https://docs.adjust.com/en/sdk-signature/) introduced by Adjust SDK 4.12.

### Why is it needed?

The app secret consists of a secret identifier and four info fields representing the secret itself. 

This app secret is verified by Adjust SDK against Adjust servers after setting it on  `ADJConfig`. Since `SEGAdjustIntegration` is in charge of creating `ADJConfig`, there is no way to customize this config object externally without changing `SEGAdjustIntegration`.

### What has been changed?

The main change consists of passing secret identifier and info fields as `SEGAdjustAppSecret` to `SEGAdjustIntegrationFactory` initializer, then `SEGAdjustIntegration` initializer. `SEGAdjustIntegrationFactory` caches the app secret object locally until `SEGAdjustIntegration` is created.

You can use the resulting API like this:

```Swift
        let configuration = SEGAnalyticsConfiguration(writeKey: key)
        let secret = SEGAdjustAppSecret(
                id: 1, 
                info1: 48730982787, 
                info2: 038762324, 
                info3: 29387611267, 
                info4: 635489772
        )

        configuration.use(SEGAdjustIntegrationFactory.instance(appSecret: secret))

        SEGAnalytics.setup(with: configuration)
```

### Notes

Initially I chose to represent the app secret as an array. However a dedicated class like `SEGAdjustSecret` seems like a better choice, it makes the API more explicit and eliminates conversion to `NSNumber` (especially when integrating with Swift where casting to `[NSNumber]` was required when using an array).