### PR TITLE
Bump sdk

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,30 +1,37 @@
 PODS:
-  - Adjust (4.11.4):
-    - Adjust/Core (= 4.11.4)
-  - Adjust/Core (4.11.4)
-  - Analytics (3.6.7)
+  - Adjust (4.15.0):
+    - Adjust/Core (= 4.15.0)
+  - Adjust/Core (4.15.0)
+  - Analytics (3.6.9)
   - Expecta (1.0.6)
   - Segment-Adjust (1.1.3):
-    - Adjust (~> 4.10)
+    - Adjust (~> 4.15)
     - Analytics (~> 3.0)
-  - Specta (1.0.6)
+  - Specta (1.0.7)
 
 DEPENDENCIES:
   - Expecta
   - Segment-Adjust (from `../`)
   - Specta
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Adjust
+    - Analytics
+    - Expecta
+    - Specta
+
 EXTERNAL SOURCES:
   Segment-Adjust:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Adjust: c3265d1c75916d727277aca22ac4b52072fc18d2
-  Analytics: 2c09a50e3478a3a7ced08a22d00c43ba6f7011e6
+  Adjust: 30d2cf13dad1a8ba08cf5082d312a26b21da3f29
+  Analytics: 6541ce337e99d9f7a2240a8b3953940a7be5f998
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  Segment-Adjust: 97c2c1ed3c6f238f855218f45f1673583357e11d
-  Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
+  Segment-Adjust: 7e0c01d23bebfb1b5f15015075486a1230543b36
+  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 6057868ba6813120a3ab5ffee3b33af7e280bbd5
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: Example/Podfile Segment-Adjust.podspec
 	pod install --project-directory=Example
 
 lint:
-	pod lib lint --verbose
+	pod lib lint --verbose --allow-warnings
 
 clean:
 	set -o pipefail && xcodebuild $(XC_ARGS) clean | xcpretty

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Releasing
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
  5. `git push && git push --tags`
- 6. `pod trunk push Segment-Adjust.podspec --use-libraries`
+ 6. `pod trunk push Segment-Adjust.podspec --use-libraries --allow-warnings`
  7. Update the version `Segment-Adjust.podspec` to the next beta version.
  8. `git commit -am "Prepare next development version."`
  9. `git push`

--- a/Segment-Adjust.podspec
+++ b/Segment-Adjust.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Adjust', '~> 4.10'
+  s.dependency 'Adjust', '~> 4.15'
 end


### PR DESCRIPTION
JIRA: [GA-596](https://segment.atlassian.net/secure/RapidBoard.jspa?rapidView=120&projectKey=GA&modal=detail&selectedIssue=GA-596)

This PR bumps the Adjust SDK to v4.15.0 which is the latest version of the SDK. The change was requested by a BT customer (Doordash). The latest Adjust SDK release includes functionality for GDPR. Our previous integration was using v4.10.

End to end testing was performed using Segment's AnalyticsObjcTestApp to ensure data was flowing properly both to Segment and to Adjust with no errors. An outline of the E2E testing, with screenshots or both dashboards can be found here:
https://paper.dropbox.com/doc/Adjust-iOS-SDK-Bump-E2E-Testing--AQrDntYCFvI_s2XWkF8_KT_5Ag-56FbCh8LEfVaYgRfD35Jm

Due to lint errors related to a warning from the SEGIntegrationsManager I have added the --allow-warnings tag to both the Makefile and RELEASING.md. 