### PR TITLE
Carthage compatibility

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "adjust/ios_sdk"
+github "segmentio/analytics-ios"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "adjust/ios_sdk" "v4.17.1"
+github "segmentio/analytics-ios" "3.6.10"

--- a/Example/Segment-Adjust.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Segment-Adjust.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Pod/Classes/SEGAdjustIntegration.h
+++ b/Pod/Classes/SEGAdjustIntegration.h
@@ -1,6 +1,15 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGAnalytics.h>
-#import <Adjust/Adjust.h>
+
+#ifdef CARTHAGE_BUILD
+    /* This header is used for XCode & Carthage build because when using adjust
+     as a Carthage dependency it is imported as AdjustSDK/Adjust.h */
+    #import <AdjustSdk/Adjust.h>
+#else
+    /* This header is used for make build because when using adjust
+     as a cocoapods dependency it is imported as Adjust/Adjust.h */
+    #import <Adjust/Adjust.h>
+#endif
 
 
 @interface SEGAdjustIntegration : NSObject <SEGIntegration, AdjustDelegate>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CircleCI](https://circleci.com/gh/segment-integrations/analytics-ios-integration-adjust.svg?style=svg)](https://circleci.com/gh/segment-integrations/analytics-ios-integration-adjust)
 [![Version](https://img.shields.io/cocoapods/v/Segment-Adjust.svg?style=flat)](http://cocoapods.org/pods/Segment-Adjust)
 [![License](https://img.shields.io/cocoapods/l/Segment-Adjust.svg?style=flat)](http://cocoapods.org/pods/Segment-Adjust)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 Adjust integration for analytics-ios.
 
@@ -12,6 +13,12 @@ To install the Segment-Adjust integration, simply add this line to your [CocoaPo
 
 ```ruby
 pod "Segment-Adjust"
+```
+
+Or add this to your [Carthage](https://github.com/Carthage/Carthage) `Cartfile`:
+
+```ruby
+github "segment-integrations/analytics-ios-integration-adjust"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,17 +9,23 @@ Adjust integration for analytics-ios.
 
 ## Installation
 
+### Cocoapods
 To install the Segment-Adjust integration, simply add this line to your [CocoaPods](http://cocoapods.org) `Podfile`:
 
 ```ruby
 pod "Segment-Adjust"
 ```
 
+### Carthage
 Or add this to your [Carthage](https://github.com/Carthage/Carthage) `Cartfile`:
 
 ```ruby
 github "segment-integrations/analytics-ios-integration-adjust"
 ```
+
+In the Xcode project, add a preprocessor macro `CARTHAGE_BUILD=1` to all targets and configurations.
+This is necessary because Adjust uses different import statements depending on if it has been added
+via Carthage or Cocoapods.
 
 ## Usage
 

--- a/SEGAdjustIntegration.xcodeproj/project.pbxproj
+++ b/SEGAdjustIntegration.xcodeproj/project.pbxproj
@@ -1,0 +1,378 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C38C3254220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = C38C324F220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.h */; };
+		C38C3257220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = C38C3252220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.m */; };
+		C38C3258220C6D3A00C77E2B /* SEGAdjustIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = C38C3253220C6D3A00C77E2B /* SEGAdjustIntegration.m */; };
+		C38C325C220C6E9600C77E2B /* AdjustSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C38C325A220C6E9600C77E2B /* AdjustSdk.framework */; };
+		C38C325D220C6E9600C77E2B /* Analytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C38C325B220C6E9600C77E2B /* Analytics.framework */; };
+		C38C3260220C809E00C77E2B /* SEGAdjustIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = C38C3250220C6D3A00C77E2B /* SEGAdjustIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		C328EFC0220C6CCD0081F5A1 /* SEGAdjustIntegration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SEGAdjustIntegration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C328EFC4220C6CCD0081F5A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C38C324F220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGAdjustIntegrationFactory.h; sourceTree = "<group>"; };
+		C38C3250220C6D3A00C77E2B /* SEGAdjustIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGAdjustIntegration.h; sourceTree = "<group>"; };
+		C38C3252220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGAdjustIntegrationFactory.m; sourceTree = "<group>"; };
+		C38C3253220C6D3A00C77E2B /* SEGAdjustIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGAdjustIntegration.m; sourceTree = "<group>"; };
+		C38C325A220C6E9600C77E2B /* AdjustSdk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdjustSdk.framework; path = Carthage/Build/iOS/AdjustSdk.framework; sourceTree = "<group>"; };
+		C38C325B220C6E9600C77E2B /* Analytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Analytics.framework; path = Carthage/Build/iOS/Analytics.framework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C328EFBD220C6CCC0081F5A1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C38C325C220C6E9600C77E2B /* AdjustSdk.framework in Frameworks */,
+				C38C325D220C6E9600C77E2B /* Analytics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C328EFB6220C6CCC0081F5A1 = {
+			isa = PBXGroup;
+			children = (
+				C328EFC2220C6CCD0081F5A1 /* SEGAdjustIntegration */,
+				C328EFC1220C6CCD0081F5A1 /* Products */,
+				C38C324E220C6D3A00C77E2B /* Classes */,
+				C38C3259220C6E9600C77E2B /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		C328EFC1220C6CCD0081F5A1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C328EFC0220C6CCD0081F5A1 /* SEGAdjustIntegration.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C328EFC2220C6CCD0081F5A1 /* SEGAdjustIntegration */ = {
+			isa = PBXGroup;
+			children = (
+				C328EFC4220C6CCD0081F5A1 /* Info.plist */,
+			);
+			path = SEGAdjustIntegration;
+			sourceTree = "<group>";
+		};
+		C38C324E220C6D3A00C77E2B /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				C38C324F220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.h */,
+				C38C3252220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.m */,
+				C38C3250220C6D3A00C77E2B /* SEGAdjustIntegration.h */,
+				C38C3253220C6D3A00C77E2B /* SEGAdjustIntegration.m */,
+			);
+			name = Classes;
+			path = Pod/Classes;
+			sourceTree = "<group>";
+		};
+		C38C3259220C6E9600C77E2B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C38C325A220C6E9600C77E2B /* AdjustSdk.framework */,
+				C38C325B220C6E9600C77E2B /* Analytics.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		C328EFBB220C6CCC0081F5A1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C38C3260220C809E00C77E2B /* SEGAdjustIntegration.h in Headers */,
+				C38C3254220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		C328EFBF220C6CCC0081F5A1 /* SEGAdjustIntegration */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C328EFC8220C6CCD0081F5A1 /* Build configuration list for PBXNativeTarget "SEGAdjustIntegration" */;
+			buildPhases = (
+				C328EFBB220C6CCC0081F5A1 /* Headers */,
+				C328EFBC220C6CCC0081F5A1 /* Sources */,
+				C328EFBD220C6CCC0081F5A1 /* Frameworks */,
+				C328EFBE220C6CCC0081F5A1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SEGAdjustIntegration;
+			productName = SEGAdjustIntegration;
+			productReference = C328EFC0220C6CCD0081F5A1 /* SEGAdjustIntegration.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C328EFB7220C6CCC0081F5A1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "Segment Integrations";
+				TargetAttributes = {
+					C328EFBF220C6CCC0081F5A1 = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = C328EFBA220C6CCC0081F5A1 /* Build configuration list for PBXProject "SEGAdjustIntegration" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = C328EFB6220C6CCC0081F5A1;
+			productRefGroup = C328EFC1220C6CCD0081F5A1 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C328EFBF220C6CCC0081F5A1 /* SEGAdjustIntegration */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C328EFBE220C6CCC0081F5A1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C328EFBC220C6CCC0081F5A1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C38C3257220C6D3A00C77E2B /* SEGAdjustIntegrationFactory.m in Sources */,
+				C38C3258220C6D3A00C77E2B /* SEGAdjustIntegration.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C328EFC6220C6CCD0081F5A1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C328EFC7220C6CCD0081F5A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C328EFC9220C6CCD0081F5A1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"CARTHAGE_BUILD=1",
+				);
+				INFOPLIST_FILE = SEGAdjustIntegration/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.segment.SEGAdjustIntegration;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C328EFCA220C6CCD0081F5A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = "CARTHAGE_BUILD=1";
+				INFOPLIST_FILE = SEGAdjustIntegration/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.segment.SEGAdjustIntegration;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C328EFBA220C6CCC0081F5A1 /* Build configuration list for PBXProject "SEGAdjustIntegration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C328EFC6220C6CCD0081F5A1 /* Debug */,
+				C328EFC7220C6CCD0081F5A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C328EFC8220C6CCD0081F5A1 /* Build configuration list for PBXNativeTarget "SEGAdjustIntegration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C328EFC9220C6CCD0081F5A1 /* Debug */,
+				C328EFCA220C6CCD0081F5A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C328EFB7220C6CCC0081F5A1 /* Project object */;
+}

--- a/SEGAdjustIntegration.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SEGAdjustIntegration.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SEGAdjustIntegration.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/SEGAdjustIntegration.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SEGAdjustIntegration.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SEGAdjustIntegration.xcodeproj/xcshareddata/xcschemes/SEGAdjustIntegration.xcscheme
+++ b/SEGAdjustIntegration.xcodeproj/xcshareddata/xcschemes/SEGAdjustIntegration.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C328EFBF220C6CCC0081F5A1"
+               BuildableName = "SEGAdjustIntegration.framework"
+               BlueprintName = "SEGAdjustIntegration"
+               ReferencedContainer = "container:SEGAdjustIntegration.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C328EFBF220C6CCC0081F5A1"
+            BuildableName = "SEGAdjustIntegration.framework"
+            BlueprintName = "SEGAdjustIntegration"
+            ReferencedContainer = "container:SEGAdjustIntegration.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C328EFBF220C6CCC0081F5A1"
+            BuildableName = "SEGAdjustIntegration.framework"
+            BlueprintName = "SEGAdjustIntegration"
+            ReferencedContainer = "container:SEGAdjustIntegration.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SEGAdjustIntegration/Info.plist
+++ b/SEGAdjustIntegration/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>


### PR DESCRIPTION
This adds Carthage compatibility by adding a Xcode project with a shared schema. 

It was tricky mainly because Adjust is imported differently depending if it is a Cocoapod or Carthage dependency. See SEGAdjustIntegration.h and README.