### PR TITLE
bump adjust to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,12 @@ Carthage
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
 Pods/
 .clang-format
+
+
+.idea

--- a/Segment-Adjust.podspec
+++ b/Segment-Adjust.podspec
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/segment-integrations/analytics-ios-integration-adjust.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/segment'
 
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '10.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics'
-  s.dependency 'Adjust', '~> 4.28'
+  s.dependency 'Adjust', '~> 4.29.3'
 end


### PR DESCRIPTION
bumps Adjust to version (4.29.3) which includes a new deduplicate ID, e.g. for Apple Ad campaigns.