### PR TITLE
Make the delimiter for revenue extraction independent from Locale

### DIFF
--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -61,6 +61,8 @@
             // Format the revenue.
             NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
             [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
+            [formatter setGroupingSeparator:@","];
+            [formatter setDecimalSeparator:@"."];
             return [formatter numberFromString:revenueProperty];
         } else if ([revenueProperty isKindOfClass:[NSNumber class]]) {
             return revenueProperty;


### PR DESCRIPTION
In the current implementation, depending on the device's locale, different string values are recognized as revenue or are rejected. 

German phone:

"0.55" → not working
"0,55" → working
US phone

"0.55" → working
"0,55" → not working

I've set fixed delimiters to match the examples from Segment's ecommerce spec.